### PR TITLE
Switch to authenticated AES-GCM encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ Le binaire sera généré dans `Encrypto/bin/Release/net8.0/linux-x64/publish/`.
 ```
 
 Ce script publie l'application si nécessaire puis exécute le binaire généré.
+
+## Format du fichier chiffré
+
+Pour l'interopérabilité, le fichier résultant du chiffrement est la concaténation des
+champs suivants :
+
+1. **Sel** : 16 octets utilisés pour la dérivation de clé (PBKDF2).
+2. **IV** : 12 octets aléatoires utilisés comme vecteur de démarrage pour AES‑GCM.
+3. **Tag** : 16 octets de tag d'authentification généré par AES‑GCM.
+4. **Ciphertext** : les données chiffrées.
+
+L'ordre est strictement `sel || IV || tag || ciphertext`.


### PR DESCRIPTION
## Summary
- replace AES-CBC stream encryption with AES-GCM using a derived key
- append authentication tag and verify it on decrypt
- document encrypted file format (salt, IV, tag, ciphertext)

## Testing
- `dotnet build`


------
https://chatgpt.com/codex/tasks/task_e_6898cb3100d483239dd1099bfd34bc38