### PR TITLE
Ensure temporary files are cleaned after encryption/decryption

### DIFF
--- a/Encrypto.Tests/Encrypto.Tests.csproj
+++ b/Encrypto.Tests/Encrypto.Tests.csproj
@@ -1,0 +1,29 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Encrypto\Encrypto.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Encrypto.Tests/GlobalUsings.cs
+++ b/Encrypto.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/Encrypto.Tests/TempFileTests.cs
+++ b/Encrypto.Tests/TempFileTests.cs
@@ -1,0 +1,56 @@
+using System;
+using System.IO;
+using Xunit;
+
+namespace Encrypto.Tests
+{
+    public class TempFileTests
+    {
+        [Fact]
+        public void EncryptProcess_DoesNotLeaveTempFiles()
+        {
+            string testDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(testDir);
+            File.WriteAllText(Path.Combine(testDir, "test.txt"), "content");
+
+            int before = Directory.GetFiles(Path.GetTempPath()).Length;
+            var encrypt = new Encrypt(testDir, "password");
+            encrypt.EncryptProcess();
+            int after = Directory.GetFiles(Path.GetTempPath()).Length;
+
+            Assert.Equal(before, after);
+            Directory.Delete(testDir, true);
+        }
+
+        [Fact]
+        public void DecryptProcess_DoesNotLeaveTempFiles()
+        {
+            // Prepare a directory to encrypt
+            string sourceDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(sourceDir);
+            File.WriteAllText(Path.Combine(sourceDir, "test.txt"), "content");
+
+            var encrypt = new Encrypt(sourceDir, "password");
+            encrypt.EncryptProcess();
+
+            // Write encrypted data to a file for decryption
+            string encryptedFile = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            File.WriteAllBytes(encryptedFile, encrypt.EncryptedData!);
+
+            string destDir = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(destDir);
+
+            int before = Directory.GetFiles(Path.GetTempPath()).Length;
+            var decrypt = new Decrypt(encryptedFile, "password", destDir);
+            decrypt.DecryptProcess();
+            int after = Directory.GetFiles(Path.GetTempPath()).Length;
+
+            Assert.Equal(before, after);
+
+            // cleanup
+            Directory.Delete(sourceDir, true);
+            Directory.Delete(destDir, true);
+            File.Delete(encryptedFile);
+        }
+    }
+}

--- a/Encrypto.sln
+++ b/Encrypto.sln
@@ -7,6 +7,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Encrypto", "Encrypto\Encryp
 EndProject
 Project("{54435603-DBB4-11D2-8724-00A0C9A8B90C}") = "Setup", "Setup\Setup.vdproj", "{58D8D6C9-E1AC-4183-A712-3F00C015B616}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Encrypto.Tests", "Encrypto.Tests\Encrypto.Tests.csproj", "{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,26 @@ Global
 		{58D8D6C9-E1AC-4183-A712-3F00C015B616}.Release|ARM64.ActiveCfg = Release
 		{58D8D6C9-E1AC-4183-A712-3F00C015B616}.Release|x64.ActiveCfg = Release
 		{58D8D6C9-E1AC-4183-A712-3F00C015B616}.Release|x86.ActiveCfg = Release
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|ARM.Build.0 = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|ARM64.ActiveCfg = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|ARM64.Build.0 = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|x64.Build.0 = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Debug|x86.Build.0 = Debug|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|ARM.ActiveCfg = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|ARM.Build.0 = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|ARM64.ActiveCfg = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|ARM64.Build.0 = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|x64.ActiveCfg = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|x64.Build.0 = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|x86.ActiveCfg = Release|Any CPU
+		{846BBEF0-BA86-41ED-9719-CA01A4A7FDB9}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Encrypto/Decrypt.cs
+++ b/Encrypto/Decrypt.cs
@@ -23,13 +23,24 @@ namespace Encrypto
         public void DecryptProcess()
         {
             DecryptedData = DecryptFile(EncryptFile);
-            UnZipFile();
+            string filename = Path.GetTempFileName();
+            try
+            {
+                UnZipFile(filename);
+            }
+            finally
+            {
+                if (File.Exists(filename))
+                {
+                    File.Delete(filename);
+                }
+            }
         }
 
-        private void UnZipFile()
+        private void UnZipFile(string filename)
         {
             if (DecryptedData == null) return;
-            string filename = Path.GetTempFileName();
+            // Using a MemoryStream with ZipArchive could remove the need for this temporary file.
             File.WriteAllBytes(filename, DecryptedData);
             ZipFile.ExtractToDirectory(filename, Destination);
         }

--- a/Encrypto/Encrypt.cs
+++ b/Encrypto/Encrypt.cs
@@ -22,13 +22,25 @@ namespace Encrypto
         public void EncryptProcess()
         {
             string zipFilename = CreateZipFile();
-            EncryptedData = EncryptFile(zipFilename);
+            try
+            {
+                EncryptedData = EncryptFile(zipFilename);
+            }
+            finally
+            {
+                if (File.Exists(zipFilename))
+                {
+                    File.Delete(zipFilename);
+                }
+            }
         }
 
         private string CreateZipFile()
         {
             string filename = Path.GetTempFileName();
             if (File.Exists(filename)) { File.Delete(filename); }
+            // An alternative approach could use a MemoryStream or FileOptions.DeleteOnClose
+            // to avoid creating a physical temporary file.
             ZipFile.CreateFromDirectory(EncryptDirectory, filename);
             return filename;
         }


### PR DESCRIPTION
## Summary
- delete temporary files with try/finally in encryption and decryption routines
- note alternatives for avoiding temporary files
- add tests confirming temp files are removed

## Testing
- `dotnet test`


------
https://chatgpt.com/codex/tasks/task_e_6898d3364a548323a21a8b890c719735