### PR TITLE
Ensure decrypt writes to valid directory

### DIFF
--- a/encrypto/Program.cs
+++ b/encrypto/Program.cs
@@ -51,10 +51,23 @@ namespace Encrypto
 
         private static int RunDecrypt(DecryptParameters opts)
         {
-            string destination = !string.IsNullOrEmpty(opts.Destination) ? opts.Destination : "./" + Path.GetFileNameWithoutExtension(opts.Source);
+            string destination = !string.IsNullOrEmpty(opts.Destination)
+                ? opts.Destination
+                : Path.Combine(Environment.CurrentDirectory, Path.GetFileNameWithoutExtension(opts.Source));
             Console.WriteLine($"[DECRYPT] Source: {opts.Source}, Destination: {destination}");
             try
             {
+                if (File.Exists(destination))
+                {
+                    Console.WriteLine($"Destination path points to an existing file: {destination}");
+                    return 1;
+                }
+
+                if (!Directory.Exists(destination))
+                {
+                    Directory.CreateDirectory(destination);
+                }
+
                 var decrypt = new Decrypt(opts.Source, opts.Password, destination);
                 decrypt.DecryptProcess();
                 Console.WriteLine("Decryption completed successfully.");


### PR DESCRIPTION
## Summary
- Use `Path.Combine` with `Environment.CurrentDirectory` for default decrypt destination
- Validate and create destination directory before running decrypt

## Testing
- `dotnet build` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_6898ea5c5168832393efa224bc40309a