### PR TITLE
Add encryption and decryption round-trip test

### DIFF
--- a/encrypto.sln
+++ b/encrypto.sln
@@ -2,15 +2,44 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encrypto", "encrypto\encrypto.csproj", "{2696F1A8-5A64-482D-8E27-234D8637113E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "encrypto.tests", "encrypto.tests\encrypto.tests.csproj", "{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|x64.Build.0 = Debug|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Debug|x86.Build.0 = Debug|Any CPU
 		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|x64.ActiveCfg = Release|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|x64.Build.0 = Release|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|x86.ActiveCfg = Release|Any CPU
+		{2696F1A8-5A64-482D-8E27-234D8637113E}.Release|x86.Build.0 = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|x64.Build.0 = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Debug|x86.Build.0 = Debug|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|x64.ActiveCfg = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|x64.Build.0 = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|x86.ActiveCfg = Release|Any CPU
+		{B533DFC5-23CB-4C58-A05E-8D4D4CE3C7B0}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/encrypto.tests/EncryptionTests.cs
+++ b/encrypto.tests/EncryptionTests.cs
@@ -1,0 +1,46 @@
+using Encrypto;
+using Xunit;
+
+namespace encrypto.tests;
+
+public class EncryptionTests
+{
+    [Fact]
+    public void EncryptDecrypt_RoundTripRestoresFiles()
+    {
+        string password = "P@ssw0rd!";
+        string sourceDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(sourceDir);
+        string originalFilePath = Path.Combine(sourceDir, "test.txt");
+        File.WriteAllText(originalFilePath, "Hello World");
+
+        string encryptedFilePath = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        string decryptedDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(decryptedDir);
+
+        try
+        {
+            var encrypt = new Encrypt(sourceDir, password);
+            encrypt.EncryptProcess();
+            Assert.NotNull(encrypt.EncryptedData);
+            File.WriteAllBytes(encryptedFilePath, encrypt.EncryptedData!);
+
+            var decrypt = new Decrypt(encryptedFilePath, password, decryptedDir);
+            decrypt.DecryptProcess();
+
+            string decryptedFilePath = Path.Combine(decryptedDir, "test.txt");
+            Assert.True(File.Exists(decryptedFilePath));
+            string decryptedContent = File.ReadAllText(decryptedFilePath);
+            Assert.Equal("Hello World", decryptedContent);
+        }
+        finally
+        {
+            if (Directory.Exists(sourceDir))
+                Directory.Delete(sourceDir, true);
+            if (File.Exists(encryptedFilePath))
+                File.Delete(encryptedFilePath);
+            if (Directory.Exists(decryptedDir))
+                Directory.Delete(decryptedDir, true);
+        }
+    }
+}

--- a/encrypto.tests/encrypto.tests.csproj
+++ b/encrypto.tests/encrypto.tests.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\encrypto\encrypto.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
## Summary
- add xUnit test project
- verify encrypt/decrypt round-trip restores original file

## Testing
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_6898f1f392e88323b9293091714bb03b